### PR TITLE
Updating manifest publish path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,37 +5,13 @@ on: # rebuild any PRs and main branch changes
     branches:
       - main
       - 'releases/*'
-      - ldennington/update-publish-path
 
 jobs:
-  test:
+  build: # make sure build/ci work properly
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Update winget repository
-        uses: ./
-        with:
-          id: Microsoft.GitCredentialManagerCore
-          version: 2.0.194.40577
-          token: ${{ secrets.WINGET_TOKEN }}
-          repo: ldennington/winget-pkgs
-          manifestText: |
-            PackageIdentifier: Microsoft.GitCredentialManagerCore
-            PackageVersion: 2.0.194.40577
-            PackageName: Git Credential Manager Core
-            Publisher: Microsoft Corporation
-            Moniker: git-credential-manager-core
-            PackageUrl: https://aka.ms/gcmcore
-            License: Copyright (C) Microsoft Corporation
-            ShortDescription: Secure, cross-platform Git credential storage with authentication to GitHub, Azure Repos, and other popular Git hosting services.
-            Installers:
-            - Architecture: x64
-              InstallerUrl: https://github.com/microsoft/Git-Credential-Manager-Core/releases/download/v2.0.194-beta/gcmcore-win-x86-2.0.194.40577.exe
-              InstallerType: inno
-              InstallerSha256: 26D3662F66E6AEC76C3BF155028D22D30ED8D1F1AFFA7C676F8DB0426939E8AD
-            PackageLocale: en-US
-            ManifestType: singleton
-            ManifestVersion: 1.0.0
-          alwaysUsePullRequest: true
-          releaseRepo: 'microsoft/Git-Credential-Manager-Core'
-          releaseTag: 'v2.0.194-beta'
+      - run: |
+          npm install
+      - run: |
+          npm run all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,13 +5,37 @@ on: # rebuild any PRs and main branch changes
     branches:
       - main
       - 'releases/*'
+      - ldennington/update-publish-path
 
 jobs:
-  build: # make sure build/ci work properly
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: |
-          npm install
-      - run: |
-          npm run all
+      - name: Update winget repository
+        uses: ./
+        with:
+          id: Microsoft.GitCredentialManagerCore
+          version: 2.0.194.40577
+          token: ${{ secrets.WINGET_TOKEN }}
+          repo: ldennington/winget-pkgs
+          manifestText: |
+            PackageIdentifier: Microsoft.GitCredentialManagerCore
+            PackageVersion: 2.0.194.40577
+            PackageName: Git Credential Manager Core
+            Publisher: Microsoft Corporation
+            Moniker: git-credential-manager-core
+            PackageUrl: https://aka.ms/gcmcore
+            License: Copyright (C) Microsoft Corporation
+            ShortDescription: Secure, cross-platform Git credential storage with authentication to GitHub, Azure Repos, and other popular Git hosting services.
+            Installers:
+            - Architecture: x64
+              InstallerUrl: https://github.com/microsoft/Git-Credential-Manager-Core/releases/download/v2.0.194-beta/gcmcore-win-x86-2.0.194.40577.exe
+              InstallerType: inno
+              InstallerSha256: 26D3662F66E6AEC76C3BF155028D22D30ED8D1F1AFFA7C676F8DB0426939E8AD
+            PackageLocale: en-US
+            ManifestType: singleton
+            ManifestVersion: 1.0.0
+          alwaysUsePullRequest: true
+          releaseRepo: 'microsoft/Git-Credential-Manager-Core'
+          releaseTag: 'v2.0.194-beta'

--- a/dist/index.js
+++ b/dist/index.js
@@ -8360,7 +8360,7 @@ function run() {
             manifestText = manifestText.replace('{{version.major_minor}}', version.toString(2));
             manifestText = manifestText.replace('{{version.major_minor_patch}}', version.toString(3));
             core.debug('computing manifest file path...');
-            const manifestFilePath = `manifests/${id.charAt(0).toLowerCase()}
+            const manifestFilePath = `manifests/${id.charAt(0).toLowerCase().trim()}
     /${id.replace('.', '/')}/${version}.yaml`;
             core.debug(`manifest file path is: ${manifestFilePath}`);
             core.debug(`final manifest is:`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -8362,7 +8362,7 @@ function run() {
             core.debug('computing manifest file path...');
             const manifestFilePath = `manifests/${id
                 .charAt(0)
-                .toLowerCase()}/${id.replace('.', '/')}/${version}.yaml`;
+                .toLowerCase()}/${id.replace('.', '/')}/${version}.yaml`.trim();
             core.debug(`manifest file path is: ${manifestFilePath}`);
             core.debug(`final manifest is:`);
             core.debug(manifestText);

--- a/dist/index.js
+++ b/dist/index.js
@@ -8360,7 +8360,8 @@ function run() {
             manifestText = manifestText.replace('{{version.major_minor}}', version.toString(2));
             manifestText = manifestText.replace('{{version.major_minor_patch}}', version.toString(3));
             core.debug('computing manifest file path...');
-            const manifestFilePath = `manifests/${id.replace('.', '/')}/${version}.yaml`;
+            const manifestFilePath = `manifests/${id.charAt(0).toLowerCase()}
+    /${id.replace('.', '/')}/${version}.yaml`;
             core.debug(`manifest file path is: ${manifestFilePath}`);
             core.debug(`final manifest is:`);
             core.debug(manifestText);

--- a/dist/index.js
+++ b/dist/index.js
@@ -8360,8 +8360,9 @@ function run() {
             manifestText = manifestText.replace('{{version.major_minor}}', version.toString(2));
             manifestText = manifestText.replace('{{version.major_minor_patch}}', version.toString(3));
             core.debug('computing manifest file path...');
-            const manifestFilePath = `manifests/${id.charAt(0).toLowerCase().trim()}
-    /${id.replace('.', '/')}/${version}.yaml`;
+            const manifestFilePath = `manifests/${id
+                .charAt(0)
+                .toLowerCase()}/${id.replace('.', '/')}/${version}.yaml`;
             core.debug(`manifest file path is: ${manifestFilePath}`);
             core.debug(`final manifest is:`);
             core.debug(manifestText);

--- a/src/main.ts
+++ b/src/main.ts
@@ -188,8 +188,9 @@ async function run(): Promise<void> {
     );
 
     core.debug('computing manifest file path...');
-    const manifestFilePath = `manifests/${id.charAt(0).toLowerCase().trim()}
-    /${id.replace('.', '/')}/${version}.yaml`;
+    const manifestFilePath = `manifests/${id
+      .charAt(0)
+      .toLowerCase()}/${id.replace('.', '/')}/${version}.yaml`;
     core.debug(`manifest file path is: ${manifestFilePath}`);
 
     core.debug(`final manifest is:`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -188,7 +188,8 @@ async function run(): Promise<void> {
     );
 
     core.debug('computing manifest file path...');
-    const manifestFilePath = `manifests/${id.replace(
+    const manifestFilePath = `manifests/${id.charAt(0).toLowerCase()}
+    /${id.replace(
       '.',
       '/'
     )}/${version}.yaml`;

--- a/src/main.ts
+++ b/src/main.ts
@@ -188,7 +188,7 @@ async function run(): Promise<void> {
     );
 
     core.debug('computing manifest file path...');
-    let manifestFilePath = `manifests/${id
+    const manifestFilePath = `manifests/${id
       .charAt(0)
       .toLowerCase()}/${id.replace('.', '/')}/${version}.yaml`.trim();
     core.debug(`manifest file path is: ${manifestFilePath}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -188,9 +188,9 @@ async function run(): Promise<void> {
     );
 
     core.debug('computing manifest file path...');
-    const manifestFilePath = `manifests/${id
+    let manifestFilePath = `manifests/${id
       .charAt(0)
-      .toLowerCase()}/${id.replace('.', '/')}/${version}.yaml`;
+      .toLowerCase()}/${id.replace('.', '/')}/${version}.yaml`.trim();
     core.debug(`manifest file path is: ${manifestFilePath}`);
 
     core.debug(`final manifest is:`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -188,7 +188,7 @@ async function run(): Promise<void> {
     );
 
     core.debug('computing manifest file path...');
-    const manifestFilePath = `manifests/${id.charAt(0).toLowerCase()}
+    const manifestFilePath = `manifests/${id.charAt(0).toLowerCase().trim()}
     /${id.replace('.', '/')}/${version}.yaml`;
     core.debug(`manifest file path is: ${manifestFilePath}`);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -189,10 +189,7 @@ async function run(): Promise<void> {
 
     core.debug('computing manifest file path...');
     const manifestFilePath = `manifests/${id.charAt(0).toLowerCase()}
-    /${id.replace(
-      '.',
-      '/'
-    )}/${version}.yaml`;
+    /${id.replace('.', '/')}/${version}.yaml`;
     core.debug(`manifest file path is: ${manifestFilePath}`);
 
     core.debug(`final manifest is:`);


### PR DESCRIPTION
Looks like winget recently changed the path to which manifests should be published. Originally, the path was:

`manifests/<organization_name>/<package_name/<version>.yml`

However, now it is:

`manifests/<first_letter_of_organization_name>/<organization_name>/<package_name/<version>.yml`

This change updates the path to which our action published manifests accordingly. I was able to test these changes with [this successful workflow](https://github.com/ldennington/update-winget/actions/runs/786657842).