### PR TITLE
Updating winget publish path (round 2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
           id: Microsoft.Git
           version: 2.31.1.vfs.0.2
           token: ${{ secrets.WINGET_TOKEN }}
-          repo: ldennington/winget-pkgs
+          repo: ldennington/winget-playground
           manifestText: |
             PackageIdentifier: Microsoft.Git
             PackageVersion: 2.31.1.vfs.0.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,13 +5,42 @@ on: # rebuild any PRs and main branch changes
     branches:
       - main
       - 'releases/*'
+      - fix-path
 
 jobs:
-  build: # make sure build/ci work properly
+  test: # make sure build/ci work properly
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: |
-          npm install
-      - run: |
-          npm run all
+      - name: Update winget repository
+        uses: ./
+        with:
+          id: Microsoft.Git
+          version: 2.31.1.vfs.0.2
+          token: ${{ secrets.WINGET_TOKEN }}
+          repo: ldennington/winget-pkgs
+          manifestText: |
+            PackageIdentifier: Microsoft.Git
+            PackageVersion: 2.31.1.vfs.0.2
+            PackageName: Microsoft Git
+            Publisher: Microsoft Corporation
+            Moniker: microsoft-git
+            PackageUrl: https://aka.ms/ms-git
+            License: Copyright (C) Microsoft Corporation
+            ShortDescription: |
+              Git distribution to support monorepo scenarios.
+              Note: This is not Git for Windows. Unless you are working in a monorepo and require
+              specific Git modifications, please run `winget install git` to start using Git for Windows.
+            Installers:
+            - Architecture: x64
+              InstallerUrl: https://github.com/microsoft/git/releases/download/v2.31.1.vfs.0.2/Git-2.31.1.vfs.0.2-64-bit.exe
+              InstallerType: inno
+              InstallerSha256: 1985df0ac94deb0c26ba0e570055caed128c9baabc4c664b9ce822f8c10caa03
+              InstallerSwitches:
+                Custom: /COMPONENTS="AUTOUPDATE"
+            PackageLocale: en-US
+            ManifestType: singleton
+            ManifestVersion: 1.0.0
+          alwaysUsePullRequest: true
+          releaseRepo: 'microsoft/git'
+          releaseTag: 'v2.31.1.vfs.0.2'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,42 +5,13 @@ on: # rebuild any PRs and main branch changes
     branches:
       - main
       - 'releases/*'
-      - fix-path
 
 jobs:
-  test: # make sure build/ci work properly
+  build: # make sure build/ci work properly
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Update winget repository
-        uses: ./
-        with:
-          id: Microsoft.Git
-          version: 2.31.1.vfs.0.2
-          token: ${{ secrets.WINGET_TOKEN }}
-          repo: ldennington/winget-playground
-          manifestText: |
-            PackageIdentifier: Microsoft.Git
-            PackageVersion: 2.31.1.vfs.0.2
-            PackageName: Microsoft Git
-            Publisher: Microsoft Corporation
-            Moniker: microsoft-git
-            PackageUrl: https://aka.ms/ms-git
-            License: Copyright (C) Microsoft Corporation
-            ShortDescription: |
-              Git distribution to support monorepo scenarios.
-              Note: This is not Git for Windows. Unless you are working in a monorepo and require
-              specific Git modifications, please run `winget install git` to start using Git for Windows.
-            Installers:
-            - Architecture: x64
-              InstallerUrl: https://github.com/microsoft/git/releases/download/v2.31.1.vfs.0.2/Git-2.31.1.vfs.0.2-64-bit.exe
-              InstallerType: inno
-              InstallerSha256: 1985df0ac94deb0c26ba0e570055caed128c9baabc4c664b9ce822f8c10caa03
-              InstallerSwitches:
-                Custom: /COMPONENTS="AUTOUPDATE"
-            PackageLocale: en-US
-            ManifestType: singleton
-            ManifestVersion: 1.0.0
-          alwaysUsePullRequest: true
-          releaseRepo: 'microsoft/git'
-          releaseTag: 'v2.31.1.vfs.0.2'
+      - run: |
+          npm install
+      - run: |
+          npm run all

--- a/dist/index.js
+++ b/dist/index.js
@@ -8362,7 +8362,7 @@ function run() {
             core.debug('computing manifest file path...');
             const manifestFilePath = `manifests/${id
                 .charAt(0)
-                .toLowerCase()}/${id.replace('.', '/')}/${version}.yaml`.trim();
+                .toLowerCase()}/${id.replace('.', '/')}/${version}/${id}.yaml`.trim();
             core.debug(`manifest file path is: ${manifestFilePath}`);
             core.debug(`final manifest is:`);
             core.debug(manifestText);

--- a/src/main.ts
+++ b/src/main.ts
@@ -190,7 +190,7 @@ async function run(): Promise<void> {
     core.debug('computing manifest file path...');
     const manifestFilePath = `manifests/${id
       .charAt(0)
-      .toLowerCase()}/${id.replace('.', '/')}/${version}.yaml`.trim();
+      .toLowerCase()}/${id.replace('.', '/')}/${version}/${id}.yaml`.trim();
     core.debug(`manifest file path is: ${manifestFilePath}`);
 
     core.debug(`final manifest is:`);


### PR DESCRIPTION
Something that escaped me when I initially updated the winget manifest path (see [this](https://github.com/mjcheetham/update-winget/pull/94) for reference) is that the new 1.0 format requires manifests to be located at:

`manifests/<first_letter_of_organization_name>/<organization_name>/<package_name/<version>/<organization_name>.<package_name>.yml`

instead of 

`manifests/<first_letter_of_organization_name>/<organization_name>/<package_name/<version>.yml`

This feels long and silly, but I had no say in the matter, so I'm making the appropriate fix in our code.

Tested by running my [validation action](https://github.com/ldennington/update-winget/runs/2506484962?check_suite_focus=true) which published a [PR](https://github.com/ldennington/winget-playground/pull/9/files) containing a manifest at the correct path in my winget-playground repo.