### PR TITLE
Creating + committing to new branches in forks

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -53513,9 +53513,8 @@ class ManifestRepo {
             else {
                 core.debug('updating via PR in fork repo');
                 // Need to update via PR from a fork
-                const fork = yield this.repo.createForkAsync(options.forkOwner);
-                commitRepo = fork;
-                commitBranch = fork.defaultBranch;
+                commitRepo = yield this.repo.createForkAsync(options.forkOwner);
+                commitBranch = yield commitRepo.createBranchAsync(`update-${Date.now().toString()}`, this.repo.defaultBranch.sha);
                 createPull = true;
             }
             // Create the commit

--- a/src/winget.ts
+++ b/src/winget.ts
@@ -73,9 +73,11 @@ export class ManifestRepo {
     } else {
       core.debug('updating via PR in fork repo');
       // Need to update via PR from a fork
-      const fork = await this.repo.createForkAsync(options.forkOwner);
-      commitRepo = fork;
-      commitBranch = fork.defaultBranch;
+      commitRepo = await this.repo.createForkAsync(options.forkOwner);
+      commitBranch = await commitRepo.createBranchAsync(
+        `update-${Date.now().toString()}`,
+        this.repo.defaultBranch.sha
+      );
       createPull = true;
     }
 


### PR DESCRIPTION
Currently, when we use our `update-winget` task to create a fork of `winget-pkgs`, we commit manifests directly to the `master` branch of that fork, which results in multi-commit, multi-file weirdness when opening PRs to the upstream. This fix ensures we instead create a new branch to commit and merge back to upstream in order to avoid this problem.

Tested this change by opening (and then very quickly closing) [this sample PR](https://github.com/microsoft/winget-pkgs/pull/13451) against `winget-pkgs`.