### PR TITLE
Handling special versioning for microsoft/git

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8322,6 +8322,10 @@ function run() {
                 }
                 else {
                     core.debug(`using first capture group for new package version: ${matches[1]}`);
+                    // winget requires we remove the 'vfs' characters from the microsoft/git manifest version to align with the version shown in Control Panel
+                    if (`${process.env.GITHUB_REPOSITORY}` === 'microsoft/git') {
+                        matches[1] = matches[1].replace('.vfs', '');
+                    }
                     version = new version_1.Version(matches[1]);
                 }
             }

--- a/src/main.ts
+++ b/src/main.ts
@@ -128,6 +128,10 @@ async function run(): Promise<void> {
         core.debug(
           `using first capture group for new package version: ${matches[1]}`
         );
+        // winget requires we remove the 'vfs' characters from the microsoft/git manifest version to align with the version shown in Control Panel
+        if (`${process.env.GITHUB_REPOSITORY}` === 'microsoft/git') {
+          matches[1] = matches[1].replace('.vfs', '');
+        }
         version = new Version(matches[1]);
       }
     }


### PR DESCRIPTION
Comments on https://github.com/microsoft/winget-pkgs/pull/16867 made it clear that winget wants our manifest version/publisher to align with those specified in Control Panel:

![image](https://user-images.githubusercontent.com/11321782/121929247-d951c280-ccf5-11eb-9cb4-e0b877f0ecf3.png)

This means we need to remove 'vfs' from the manifest version/path and update our publisher from 'Microsoft Corporation' to 'The Git Development Community'. 

Making the change to remove 'vfs' from the version/path here, then after release will follow up to bump microsoft/git to the latest version of this action + update the publisher.