### PR TITLE
Fix url and path when version regex specified

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8258,7 +8258,7 @@ function formatManifest(format, id, sha256, url, version) {
         .replace(/{{url}}/g, url);
 }
 function run() {
-    var _a, _b;
+    var _a, _b, _c, _d;
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const token = core.getInput('token');
@@ -8357,14 +8357,17 @@ function run() {
                 sha256 = yield hash_1.computeSha256Async(fullUrl);
                 core.debug(`sha256=${sha256}`);
             }
+            core.debug(`computing path version, using regex if applicable...`);
+            const versionRegEx = /{{version:.+}}/g;
+            const pathVersion = (_d = (_c = manifestText.match(versionRegEx)) === null || _c === void 0 ? void 0 : _c.shift()) !== null && _d !== void 0 ? _d : version.toString();
             core.debug('generating manifest...');
-            manifestText = formatManifest(manifestText, id, sha256, url, version);
+            manifestText = formatManifest(manifestText, id, sha256, fullUrl, version);
             core.debug('final manifest is:');
             core.debug(manifestText);
             core.debug('computing manifest file path...');
             const manifestFilePath = `manifests/${id
                 .charAt(0)
-                .toLowerCase()}/${id.replace('.', '/')}/${version}/${id}.yaml`.trim();
+                .toLowerCase()}/${id.replace('.', '/')}/${version.format(pathVersion)}/${id}.yaml`.trim();
             core.debug(`manifest file path is: ${manifestFilePath}`);
             core.debug('generating message...');
             const fullMessage = formatMessage(message, id, manifestFilePath, version);

--- a/src/main.ts
+++ b/src/main.ts
@@ -179,11 +179,6 @@ async function run(): Promise<void> {
       core.debug(`sha256=${sha256}`);
     }
 
-    core.debug(`computing path version, using regex if applicable...`);
-    const versionRegEx = /{{version:.+}}/g;
-    const pathVersion =
-      manifestText.match(versionRegEx)?.shift() ?? version.toString();
-
     core.debug('generating manifest...');
     manifestText = formatManifest(manifestText, id, sha256, fullUrl, version);
     core.debug('final manifest is:');

--- a/src/main.ts
+++ b/src/main.ts
@@ -184,6 +184,22 @@ async function run(): Promise<void> {
     core.debug('final manifest is:');
     core.debug(manifestText);
 
+core.debug(
+  "computing file path version from final manifest property 'PackageVersion'..."
+);
+const pkgVerRegEx = /PackageVersion:\s*(?<version>.*)/;
+const pkgVerMatch = manifestText.match(pkgVerRegEx);
+let pathVersion: string | undefined;
+if (pkgVerMatch?.groups?.version) {
+  pathVersion = pkgVerMatch.groups.version;
+} else {
+  core.warning(
+    "could not match 'PackageVersion' property in manifest; manifest may not be valid!"
+  );
+  pathVersion = version.toString();
+}
+core.debug(`path version is ${pathVersion}`);
+
     core.debug('computing manifest file path...');
     const manifestFilePath = `manifests/${id
       .charAt(0)

--- a/src/main.ts
+++ b/src/main.ts
@@ -192,9 +192,7 @@ async function run(): Promise<void> {
     core.debug('computing manifest file path...');
     const manifestFilePath = `manifests/${id
       .charAt(0)
-      .toLowerCase()}/${id.replace('.', '/')}/${version.format(
-      pathVersion
-    )}/${id}.yaml`.trim();
+      .toLowerCase()}/${id.replace('.', '/')}/${pathVersion}/${id}.yaml`.trim();
     core.debug(`manifest file path is: ${manifestFilePath}`);
 
     core.debug('generating message...');

--- a/src/main.ts
+++ b/src/main.ts
@@ -179,15 +179,22 @@ async function run(): Promise<void> {
       core.debug(`sha256=${sha256}`);
     }
 
+    core.debug(`computing path version, using regex if applicable...`);
+    const versionRegEx = /{{version:.+}}/g;
+    const pathVersion =
+      manifestText.match(versionRegEx)?.shift() ?? version.toString();
+
     core.debug('generating manifest...');
-    manifestText = formatManifest(manifestText, id, sha256, url, version);
+    manifestText = formatManifest(manifestText, id, sha256, fullUrl, version);
     core.debug('final manifest is:');
     core.debug(manifestText);
 
     core.debug('computing manifest file path...');
     const manifestFilePath = `manifests/${id
       .charAt(0)
-      .toLowerCase()}/${id.replace('.', '/')}/${version}/${id}.yaml`.trim();
+      .toLowerCase()}/${id.replace('.', '/')}/${version.format(
+      pathVersion
+    )}/${id}.yaml`.trim();
     core.debug(`manifest file path is: ${manifestFilePath}`);
 
     core.debug('generating message...');


### PR DESCRIPTION
Making a couple tweaks to finish up the changes to handle special microsoft/git versioning. Specifically, we need to ensure the path version aligns with the manifest version (winget requirement) and pass the `fullUrl` rather than `url` for formatting.

[This](https://github.com/ldennington/winget-playground/pull/41/files) is an example of what our PRs will look like with these changes applied.

[Here](https://github.com/github/git-client/issues/456) is the tracking issue for this work (I can't seem to link directly since it's not in this repo).