### PR TITLE
Allow updates to existing winget manifests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "update-winget",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -184,21 +184,21 @@ async function run(): Promise<void> {
     core.debug('final manifest is:');
     core.debug(manifestText);
 
-core.debug(
-  "computing file path version from final manifest property 'PackageVersion'..."
-);
-const pkgVerRegEx = /PackageVersion:\s*(?<version>.*)/;
-const pkgVerMatch = manifestText.match(pkgVerRegEx);
-let pathVersion: string | undefined;
-if (pkgVerMatch?.groups?.version) {
-  pathVersion = pkgVerMatch.groups.version;
-} else {
-  core.warning(
-    "could not match 'PackageVersion' property in manifest; manifest may not be valid!"
-  );
-  pathVersion = version.toString();
-}
-core.debug(`path version is ${pathVersion}`);
+    core.debug(
+      "computing file path version from final manifest property 'PackageVersion'..."
+    );
+    const pkgVerRegEx = /PackageVersion:\s*(?<version>.*)/;
+    const pkgVerMatch = manifestText.match(pkgVerRegEx);
+    let pathVersion: string | undefined;
+    if (pkgVerMatch?.groups?.version) {
+      pathVersion = pkgVerMatch.groups.version;
+    } else {
+      core.warning(
+        "could not match 'PackageVersion' property in manifest; manifest may not be valid!"
+      );
+      pathVersion = version.toString();
+    }
+    core.debug(`path version is ${pathVersion}`);
 
     core.debug('computing manifest file path...');
     const manifestFilePath = `manifests/${id

--- a/src/winget.ts
+++ b/src/winget.ts
@@ -81,14 +81,35 @@ export class ManifestRepo {
       createPull = true;
     }
 
+    let commit: Git.Commit;
+
     // Create the commit
     core.debug('creating commit...');
-    const commit = await commitRepo.commitFileAsync(
-      commitBranch.name,
-      options.filePath,
-      options.manifest,
-      options.message
-    );
+    try {
+      core.debug('checking if file exists...');
+      const existingSha = (
+        await commitRepo.getFileAsync(
+          options.filePath,
+          commitRepo.defaultBranch.name
+        )
+      ).blob;
+      core.debug('file exists, updating...');
+      commit = await commitRepo.commitFileAsync(
+        commitBranch.name,
+        options.filePath,
+        options.manifest,
+        options.message,
+        existingSha
+      );
+    } catch {
+      core.debug('file does not exist, creating...');
+      commit = await commitRepo.commitFileAsync(
+        commitBranch.name,
+        options.filePath,
+        options.manifest,
+        options.message
+      );
+    }
 
     if (!createPull) {
       return commit;


### PR DESCRIPTION
We recently received notification from a customer that installing
`microsoft/git` via winget was broken due to a signing issue. This happened
because we accidentally deployed an incorrect SHA for the `microsoft/git`
version `2.33.0.0.0` manifest on `microsoft/winget-pkgs` then replaced
the asset on GitHub with a new version with a new SHA.

When we tried to re-run the `update-winget` workflow
to correct the SHA, we discovered some issues with the action that make it
impossible to update existing manifests. This PR updates the action to allow
us to both create new winget manifests and update existing ones.

[Here](https://github.com/ldennington/winget-playground/pull/47) is an example of a test PR opened to update an existing manifest with these changes. 

And [here](https://github.com/ldennington/winget-playground/pull/48) is an example of a test PR that creates a new manifest with these changes.