### PR TITLE
Add comment to winget PRs

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8244,11 +8244,11 @@ const hash_1 = __webpack_require__(652);
 function formatUrl(format, version) {
     return version.format(format);
 }
-function formatMessage(format, id, filePath, version) {
-    return version
+function formatMessage(format, id, filePath, version, comment) {
+    return `${version
         .format(format)
         .replace(/{{id}}/g, id)
-        .replace(/{{file}}/g, filePath);
+        .replace(/{{file}}/g, filePath)}\n${comment}`;
 }
 function formatManifest(format, id, sha256, url, version) {
     return version
@@ -8378,8 +8378,10 @@ function run() {
                 .charAt(0)
                 .toLowerCase()}/${id.replace('.', '/')}/${pathVersion}/${id}.yaml`.trim();
             core.debug(`manifest file path is: ${manifestFilePath}`);
+            const comment = `Creating manifest for new release of ${id} (version ${version})`;
+            core.debug(`PR comment is: ${comment}`);
             core.debug('generating message...');
-            const fullMessage = formatMessage(message, id, manifestFilePath, version);
+            const fullMessage = formatMessage(message, id, manifestFilePath, version, comment);
             core.debug('final message is:');
             core.debug(fullMessage);
             core.debug('publishing manifest...');

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,12 +13,13 @@ function formatMessage(
   format: string,
   id: string,
   filePath: string,
-  version: Version
+  version: Version,
+  comment: string
 ): string {
-  return version
+  return `${version
     .format(format)
     .replace(/{{id}}/g, id)
-    .replace(/{{file}}/g, filePath);
+    .replace(/{{file}}/g, filePath)}\n${comment}`;
 }
 
 function formatManifest(
@@ -206,8 +207,18 @@ async function run(): Promise<void> {
       .toLowerCase()}/${id.replace('.', '/')}/${pathVersion}/${id}.yaml`.trim();
     core.debug(`manifest file path is: ${manifestFilePath}`);
 
+    const comment = `Creating manifest for new release of ${id} (version ${version})`;
+    core.debug(`PR comment is: ${comment}`);
+
     core.debug('generating message...');
-    const fullMessage = formatMessage(message, id, manifestFilePath, version);
+    const fullMessage = formatMessage(
+      message,
+      id,
+      manifestFilePath,
+      version,
+      comment
+    );
+
     core.debug('final message is:');
     core.debug(fullMessage);
 


### PR DESCRIPTION
I am becoming concerned that `wingetcreate` is not robust enough to support us yet. See [#188](https://github.com/microsoft/winget-create/discussions/188) for details. So, I took a bit of time to fix the bug in update-winget that @mjcheetham pointed out yesterday.

We are currently publishing winget PRs with 'null' in the description (referred to here as 'comment'). This change should correct that so the 'comment' for each PR generated by this task is:

Creating manifest for new release of <id> (version <version>)

I tested with a [successful run in my fork](https://github.com/ldennington/update-winget/actions/runs/1343794215), which created [this PR](https://github.com/ldennington/winget-playground/pull/50) against the `winget-playground` repository.